### PR TITLE
Adding an optional REGISTRY_CACHE to allow for caching between different hosts

### DIFF
--- a/task.go
+++ b/task.go
@@ -55,13 +55,21 @@ func Build(buildkitd *Buildkitd, outputsDir string, req Request) (Response, erro
 		)
 	}
 
-	if _, err := os.Stat(cacheDir); err == nil {
+	if cfg.RegistryCache != "" {
+		buildctlArgs = append(buildctlArgs,
+			"--export-cache", "type=registry,ref="+cfg.RegistryCache,
+		)
+	} else if _, err := os.Stat(cacheDir); err == nil {
 		buildctlArgs = append(buildctlArgs,
 			"--export-cache", "type=local,mode=min,dest="+cacheDir,
 		)
 	}
 
-	if _, err := os.Stat(filepath.Join(cacheDir, "index.json")); err == nil {
+	if cfg.RegistryCache != "" {
+		buildctlArgs = append(buildctlArgs,
+			"--import-cache", "type=registry,ref="+cfg.RegistryCache,
+		)
+	} else if _, err := os.Stat(filepath.Join(cacheDir, "index.json")); err == nil {
 		buildctlArgs = append(buildctlArgs,
 			"--import-cache", "type=local,src="+cacheDir,
 		)

--- a/types.go
+++ b/types.go
@@ -59,6 +59,8 @@ type Config struct {
 	//
 	// Theoretically this would go away if/when we standardize on OCI.
 	UnpackRootfs bool `json:"unpack_rootfs" envconfig:"optional"`
+
+	RegistryCache string `json:"registry_cache"      envconfig:"optional"`
 }
 
 // ImageMetadata is the schema written to manifest.json when producing the


### PR DESCRIPTION
So I realize this solution is not ideal but I needed a workaround with the current functionality available in this repo. I'm open to other solutions but this seemed like a good place to start this conversation. 

Probably the most logical solution for this would be adding a resource type for the registry cache to allow putting the cache the same way put the image. Another option might be to write the cache to a file resource and then pass it in as an input. Both of these solutions would need to be getable with no versions available (for the first time build). They would also require changing up how the local cache works since that is currently mounted as a volume (which would wipe out any inputs).