### PR TITLE
Source task parameter

### DIFF
--- a/task.go
+++ b/task.go
@@ -36,13 +36,24 @@ func Build(buildkitd *Buildkitd, outputsDir string, req Request) (Response, erro
 	dockerfileDir := filepath.Dir(cfg.DockerfilePath)
 	dockerfileName := filepath.Base(cfg.DockerfilePath)
 
+	var frontend string
+	if cfg.Source == "" {
+		frontend = "dockerfile.v0"
+	} else {
+		frontend = "gateway.v0"
+	}
+
 	buildctlArgs := []string{
 		"build",
 		"--progress", "plain",
-		"--frontend", "dockerfile.v0",
+		"--frontend", frontend,
 		"--local", "context=" + cfg.ContextDir,
 		"--local", "dockerfile=" + dockerfileDir,
 		"--opt", "filename=" + dockerfileName,
+	}
+
+	if cfg.Source != "" {
+		buildctlArgs = append(buildctlArgs, "--opt", "source="+cfg.Source)
 	}
 
 	var imagePath, digestPath string

--- a/types.go
+++ b/types.go
@@ -47,6 +47,7 @@ type Config struct {
 	Debug bool `json:"debug" envconfig:"optional"`
 
 	ContextDir     string `json:"context"              envconfig:"CONTEXT,optional"`
+	Source         string `json:"source,omitempty"     envconfig:"SOURCE,optional"`
 	DockerfilePath string `json:"dockerfile,omitempty" envconfig:"DOCKERFILE,optional"`
 
 	Target     string `json:"target"      envconfig:"optional"`


### PR DESCRIPTION
It allows usage of `gateway.v0` frontend.

```YAML
params:
  CONTEXT: repo
  SOURCE: denzp/cargo-wharf-frontend:latest
  DOCKERFILE: repo/Cargo.toml
```