### PR TITLE
Add IMAGE_PLATFORM param

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,11 @@ Next, any of the following optional parameters may be specified:
   name. For example, `IMAGE_ARG_base_image=ubuntu/image.tar` will set
   `base_image` to a local image reference for using `ubuntu/image.tar`.
 
+* `IMAGE_PLATFORM`: Specify the target platform to build the image for. For
+  example `IMAGE_PLATFORM=linux/arm64` will build the image for the Linux OS
+  and `arm64` architecture. By default, images will be built for the current
+  worker's platform that the task is running on.
+
 * `$LABEL_*`: params prefixed with `LABEL_` will be set as image labels.
   For example `LABEL_foo=bar`, will set the `foo` label to `bar`.
 

--- a/task.go
+++ b/task.go
@@ -148,6 +148,12 @@ func Build(buildkitd *Buildkitd, outputsDir string, req Request) (Response, erro
 		)
 	}
 
+	if req.Config.ImagePlatform != "" {
+		buildctlArgs = append(buildctlArgs,
+			"--opt", "platform="+req.Config.ImagePlatform,
+		)
+	}
+
 	builds = append(builds, buildctlArgs)
 	targets = append(targets, "")
 

--- a/task_test.go
+++ b/task_test.go
@@ -531,6 +531,14 @@ func (s *TaskSuite) TestAddHosts() {
 	s.NoError(err)
 }
 
+func (s *TaskSuite) TestImagePlatform() {
+	s.req.Config.ContextDir = "testdata/basic"
+	s.req.Config.ImagePlatform = "linux/arm64"
+
+	_, err := s.build()
+	s.NoError(err)
+}
+
 func (s *TaskSuite) build() (task.Response, error) {
 	return task.Build(s.buildkitd, s.outputsDir, s.req)
 }

--- a/task_test.go
+++ b/task_test.go
@@ -537,6 +537,15 @@ func (s *TaskSuite) TestImagePlatform() {
 
 	_, err := s.build()
 	s.NoError(err)
+
+	image, err := tarball.ImageFromPath(s.imagePath("image.tar"), nil)
+	s.NoError(err)
+
+	configFile, err := image.ConfigFile()
+	s.NoError(err)
+
+	s.Equal("linux", configFile.OS)
+	s.Equal("arm64", configFile.Architecture)
 }
 
 func (s *TaskSuite) build() (task.Response, error) {

--- a/types.go
+++ b/types.go
@@ -77,6 +77,8 @@ type Config struct {
 	ImageArgs []string `json:"image_args" envconfig:"optional"`
 
 	AddHosts string `json:"add_hosts" envconfig:"BUILDKIT_ADD_HOSTS,optional"`
+
+	ImagePlatform string `json:"image_platform" envconfig:"optional"`
 }
 
 // ImageMetadata is the schema written to manifest.json when producing the


### PR DESCRIPTION
Allows users to build images for other platforms like `linux/arm64`