### PR TITLE
Bump buildkit 0.8.3 -> 0.9.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ FROM concourse/golang-builder AS builder
   RUN go build -o /assets/task ./cmd/task
   RUN go build -o /assets/build ./cmd/build
 
-FROM moby/buildkit:v0.8.3 AS task
+FROM moby/buildkit:v0.9.1 AS task
   COPY --from=builder /assets/task /usr/bin/
   COPY --from=builder /assets/build /usr/bin/
   COPY bin/setup-cgroups /usr/bin/

--- a/scripts/setup-buildkit.sh
+++ b/scripts/setup-buildkit.sh
@@ -1,5 +1,5 @@
 if ! which buildctl >/dev/null || ! which buildkitd >/dev/null; then
-  BUILDKIT_VERSION=0.8.3
+  BUILDKIT_VERSION=0.9.1
   BUILDKIT_URL=https://github.com/moby/buildkit/releases/download/v$BUILDKIT_VERSION/buildkit-v$BUILDKIT_VERSION.linux-amd64.tar.gz
 
   curl -fL "$BUILDKIT_URL" | tar zxf -


### PR DESCRIPTION
We seem to be experiencing [this issue](https://github.com/docker/buildx/issues/369) with the current version.