### PR TITLE
Fix infinite wait on stuck progress bars

### DIFF
--- a/unpack.go
+++ b/unpack.go
@@ -67,6 +67,8 @@ func unpackImage(dest string, img v1.Image, debug bool) error {
 		if err != nil {
 			return err
 		}
+
+		bars[i].SetTotal(bars[i].Current(), true)
 	}
 
 	progress.Wait()


### PR DESCRIPTION
Sometimes builds would be stuck on 100% and never complete.

Similar to:
https://github.com/concourse/registry-image-resource/issues/303

Completing progress bars explicitly solves this issue for me.

Signed-off-by: Nico Schieder <code@nico-schieder.de>