### PR TITLE
Fix image args that are uppercase

### DIFF
--- a/task_test.go
+++ b/task_test.go
@@ -373,6 +373,43 @@ func (s *TaskSuite) TestImageArgs() {
 	}
 }
 
+func (s *TaskSuite) TestImageArgsWithUppercaseName() {
+	imagesDir, err := ioutil.TempDir("", "preload-images")
+	s.NoError(err)
+
+	defer os.RemoveAll(imagesDir)
+
+	image, err := random.Image(1024, 2)
+	s.NoError(err)
+	imagePath := filepath.Join(imagesDir, "first.tar")
+	err = tarball.WriteToFile(imagePath, nil, image)
+	s.NoError(err)
+
+	s.req.Config.ContextDir = "testdata/image-args"
+	s.req.Config.DockerfilePath = "testdata/image-args/Dockerfile.uppercase"
+	s.req.Config.ImageArgs = []string{
+		"FIRST_IMAGE=" + imagePath,
+	}
+	s.req.Config.UnpackRootfs = true
+
+	_, err = s.build()
+	s.NoError(err)
+
+	meta, err := s.imageMetadata("image")
+	s.NoError(err)
+
+	rootfsContent, err := ioutil.ReadFile(s.imagePath("rootfs", "Dockerfile.second"))
+	s.NoError(err)
+
+	expectedContent, err := ioutil.ReadFile("testdata/image-args/Dockerfile.uppercase")
+	s.NoError(err)
+
+	s.Equal(rootfsContent, expectedContent)
+
+	s.Equal(meta.User, "banana")
+	s.Equal(meta.Env, []string{"PATH=/darkness", "BA=nana"})
+}
+
 func (s *TaskSuite) TestImageArgsUnpack() {
 	imagesDir, err := ioutil.TempDir("", "preload-images")
 	s.NoError(err)

--- a/testdata/image-args/Dockerfile.uppercase
+++ b/testdata/image-args/Dockerfile.uppercase
@@ -1,0 +1,7 @@
+ARG FIRST_IMAGE
+
+FROM ${FIRST_IMAGE}
+USER banana
+ENV PATH=/darkness
+ENV BA=nana
+COPY Dockerfile.uppercase /Dockerfile.second


### PR DESCRIPTION
If a Dockerfile contained a build arg that was uppercase for referencing
an image, building would result in an error:

```
failed to parse stage name "localhost:42545/FIRST_IMAGE": invalid reference format: repository name must be lowercase
```

This commit allows users to specify args as all uppercase and lowercases
the name behind the scenes. Uppercase args are common in wild
Dockerfiles