### PR TITLE
Properly cleanup daemon on buildkit failure

### DIFF
--- a/cmd/task/main.go
+++ b/cmd/task/main.go
@@ -38,6 +38,9 @@ func main() {
 	failIf("start buildkitd", err)
 
 	res, err := task.Build(buildkitd, wd, req)
+	if err != nil {
+		buildkitd.Cleanup()
+	}
 	failIf("build", err)
 
 	err = buildkitd.Cleanup()


### PR DESCRIPTION
Hello,

Here is an example of failure logs I have without this fix:
```
FATA[0010] failed to build: create local image registry: image from path: open alpine-latest/image.tar: no such file or directory 
FATA[0011] failed to run task: exit status 1            
```
And the Concourse task hangs until manually terminated.

So, I'm suggesting here a fix a a lack of cleanup on the BuildKit daemon whenever the `buildkit` CLI invocation fails.

Best,
Benjamin