### PR TITLE
Add support for passing secrets as text (#78)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ _(As a convention in the list below, all task parameters are specified with a
   DO_THING=false
   ```
 
-* `$BUILDKIT_SECRET_*`: extra secrets which are made available via
+* `$BUILDKIT_SECRET_*`: files with extra secrets which are made available via
   `--mount=type=secret,id=...`. See [New Docker Build secret information](https://docs.docker.com/develop/develop-images/build_enhancements/#new-docker-build-secret-information) for more information on build secrets.
 
   For example, running with `BUILDKIT_SECRET_config=my-repo/config` will allow
@@ -100,6 +100,13 @@ _(As a convention in the list below, all task parameters are specified with a
   ```
   RUN --mount=type=secret,id=config cat /run/secrets/config
   ```
+
+* `$BUILDKIT_SECRETTEXT_*`: literal text of extra secrets to be made available
+  via the same mechanism described for `$BUILDKIT_SECRET_*` above. The
+  difference is that this is easier to use with credential managers:
+
+  `BUILDKIT_SECRETTEXT_mysecret=(( mysecret ))` puts the content that
+  `(( mysecret ))` expands to in `/run/secrets/mysecret`.
 
 * `$IMAGE_ARG_*`: params prefixed with `IMAGE_ARG_*` point to image tarballs
   (i.e. `docker save` format) to preload so that they do not have to be fetched

--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -3,10 +3,8 @@ package main
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -66,14 +64,8 @@ func main() {
 			seg := strings.SplitN(
 				strings.TrimPrefix(env, buildkitSecretTextPrefix), "=", 2)
 
-			// Q: Filter for environment variable names that are also legal shell variable names to disallow ../ etc?
-			secretDir := filepath.Join(os.TempDir(), "buildkit-secrets")
-			secretFile := filepath.Join(secretDir, seg[0])
-			err := os.MkdirAll(secretDir, 0700)
-			failIf("create secret directory", err)
-			err = ioutil.WriteFile(secretFile, []byte(seg[1]), 0600)
-			failIf("write to secret directory", err)
-			req.Config.BuildkitSecrets[seg[0]] = secretFile
+			err := task.StoreSecret(&req, seg[0], seg[1])
+			failIf("store secret provided as text", err)
 		}
 	}
 

--- a/task_test.go
+++ b/task_test.go
@@ -250,6 +250,15 @@ func (s *TaskSuite) TestUnpackRootfs() {
 	s.Equal(meta.Env, []string{"PATH=/darkness", "BA=nana"})
 }
 
+func (s *TaskSuite) TestBuildkitTextualSecrets() {
+	s.req.Config.ContextDir = "testdata/buildkit-secret"
+	err := task.StoreSecret(&s.req, "secret", "hello-world")
+	s.NoError(err)
+
+	_, err = s.build()
+	s.NoError(err)
+}
+
 func (s *TaskSuite) TestBuildkitSecrets() {
 	s.req.Config.ContextDir = "testdata/buildkit-secret"
 	s.req.Config.BuildkitSecrets = map[string]string{"secret": "testdata/buildkit-secret/secret"}


### PR DESCRIPTION
To preserve the existing meaning of `BUILDKIT_SECRET_`, a new `BUILDKIT_SECRETTEXT_` prefix is added, which writes content to a file before adding corresponding entry to the `BuildkitSecrets` map.

These contents are created in `buildkit-secrets/` inside the default temporary directory; since the Docker container this all happens in is transient, no need to clean them up.

See #78 for motivation.