### PR TITLE
docs(readme): fix masked link typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,9 +148,9 @@ _(As a convention in the list below, all task parameters are specified with a
   option](https://concourse-ci.org/jobs.html#schema.step.task-step.image).
 
 * `$OUTPUT_OCI` (default `false`): outputs an OCI compliant image, allowing
-  for multi-arch image builds when setting IMAGE_PLATFORM to [multiple platforms]
-  (https://docs.docker.com/desktop/extensions-sdk/extensions/multi-arch/). The
-  image output format will be a directory when this flag is set to true.
+  for multi-arch image builds when setting IMAGE_PLATFORM to
+  [multiple platforms](https://docs.docker.com/desktop/extensions-sdk/extensions/multi-arch/).
+  The image output format will be a directory when this flag is set to true.
 
 * `$BUILDKIT_ADD_HOSTS` (default empty): extra host definitions for `buildkit`
   to properly resolve custom hostnames. The value is as comma-separated


### PR DESCRIPTION
Previously the masked link had a whitespace between text and link so it didn't actually work and showed as 
```md
[multiple platforms] (https://docs.docker.com/desktop/extensions-sdk/extensions/multi-arch/)
```