### PR TITLE
Add qemu binaries back into the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,16 +17,20 @@ ENV CGO_ENABLED=0
 RUN go build -o /assets/task ./cmd/task
 RUN go build -o /assets/build ./cmd/build
 
-FROM ${base_image} AS task
 ARG BUILDKIT_VERSION=0.22.0
+WORKDIR /buildkit
+RUN apk --no-cache add curl
+RUN curl -L "https://github.com/moby/buildkit/releases/download/v${BUILDKIT_VERSION}/buildkit-v${BUILDKIT_VERSION}.linux-${TARGETARCH}.tar.gz" -o buildkit.tar.gz && \
+    tar xf buildkit.tar.gz
+
+FROM ${base_image} AS task
 RUN apk --no-cache add \
-    "buildkitd=~${BUILDKIT_VERSION}" \
-    "buildctl=~${BUILDKIT_VERSION}" \
     cmd:umount \
     cmd:mount \
     cmd:mountpoint
 COPY --from=builder /assets/task /usr/bin/
 COPY --from=builder /assets/build /usr/bin/
+COPY --from=builder /buildkit/bin/ /usr/bin/
 COPY bin/setup-cgroups /usr/bin/
 RUN for cmd in task build buildkitd buildctl mount umount mountpoint setup-cgroups; do \
     which $cmd >/dev/null || { echo "$cmd binary not found!"; exit 1; }; \


### PR DESCRIPTION
Found out the the buildkitd package from Wolfi doesn't include the qemu binaries needed for multi-arch building. I tried to see if they had them in another package but my search turned up nothing.

Instead of using wolfi's package repo to install buildkit and the qemu binaries, we fall back to downloading the binaries from the official github release.

I built and tested the new image in a pipeline. With 0.13.0 the pipeline failed with the `exec format` error. With the updated image, I was able to successfully build the multi-arch image again.