### PR TITLE
add ca-certificates to oci image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN curl -L "https://github.com/moby/buildkit/releases/download/v${BUILDKIT_VERS
 
 FROM ${base_image} AS task
 RUN apk --no-cache add \
+    ca-certificates \
     cmd:umount \
     cmd:mount \
     cmd:mountpoint


### PR DESCRIPTION
To support user workarounds (https://github.com/concourse/oci-build-task/issues/70#issuecomment-933674965) for adding CA certs before starting the build process. Long-term, someone should add a way to add ca-certs.

Another potential workaround is to pass in additional buildkit config and set the CA certificate yourself: https://docs.docker.com/build/buildkit/configure/#setting-registry-certificates

Which can be done with `BUILDKIT_EXTRA_CONFIG` and the ability to mount task inputs at absolute locations now.