### PR TITLE
Accept .json files for build_args_file, not just .yml/.yaml

### DIFF
--- a/task.go
+++ b/task.go
@@ -375,7 +375,9 @@ func sanitize(cfg *Config) error {
 			return errors.Wrap(err, "read build args file")
 		}
 
-		if strings.HasSuffix(cfg.BuildArgsFile, ".yml") || strings.HasSuffix(cfg.BuildArgsFile, ".yaml") {
+		if strings.HasSuffix(cfg.BuildArgsFile, ".yml") ||
+			strings.HasSuffix(cfg.BuildArgsFile, ".yaml") ||
+			strings.HasSuffix(cfg.BuildArgsFile, ".json") {
 			var buildArgsData map[string]string
 			err = yaml.Unmarshal(buildArgs, &buildArgsData)
 			if err != nil {

--- a/task_test.go
+++ b/task_test.go
@@ -164,6 +164,15 @@ func (s *TaskSuite) TestBuildArgsYamlFile() {
 	s.NoError(err)
 }
 
+func (s *TaskSuite) TestBuildArgsJsonFile() {
+	s.req.Config.ContextDir = "testdata/build-args"
+	s.req.Config.BuildArgsFile = "testdata/build-args/build_args_file.json"
+
+	// the Dockerfile itself asserts that the arg has been received
+	_, err := s.build()
+	s.NoError(err)
+}
+
 func (s *TaskSuite) TestBuildArgsStaticAndFile() {
 	s.req.Config.ContextDir = "testdata/build-args"
 	s.req.Config.BuildArgs = []string{"some_arg=some_value"}

--- a/testdata/build-args/build_args_file.json
+++ b/testdata/build-args/build_args_file.json
@@ -1,0 +1,1 @@
+{"some_arg": "some_value", "some_other_arg": "some_other_value"}


### PR DESCRIPTION
JSON is valid YAML and the docker-image resource consumes JSON-formatted build args files. Previously users migrating to build-task had to rename or convert their file to a .yml extension even though its contents were already valid. Now any file with a .json suffix is also parsed through the YAML unmarshaller (which handles JSON natively), matching the existing behaviour for .yml/.yaml files.